### PR TITLE
Change rest of pipeline timezones to "Europe/Helsinki"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Test 🧪
       env:
-        TZ: America/New_York
+        TZ: Europe/Helsinki
       run: npm test
 
     - name: Publish 📚

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test 🧪
         env:
-          TZ: America/New_York
+          TZ: Europe/Helsinki
         run: npm test
 
       - name: Publish 📚


### PR DESCRIPTION
There are some tests that are timezone-sensitive. To make local testing hassle-free for E-kirjasto devs, these are changed to use "Europe/Helsinki" timezone. This PR updates test-and-tag and release actions to use same timezone for the tests. (Other actions use it already.)
