### PR TITLE
Fix language facets hidden behind footer

### DIFF
--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -59,3 +59,4 @@ $fontfamily: 'Open Sans', sans-serif;
 @import "with_edit_button";
 @import "with_remove_button";
 @import "finland_statistics";
+@import "finland_facet_groups";

--- a/src/stylesheets/finland_facet_groups.scss
+++ b/src/stylesheets/finland_facet_groups.scss
@@ -1,0 +1,4 @@
+// fix facet groups hidden behind footer
+.facet-groups {
+  padding-bottom: 56px;
+}


### PR DESCRIPTION
## Description

The last facet options are being hidden behind the footer. To fix this, just added some padding for the facet groups. Could be fixed in a more general way with flex box, but this simple fix will keep future upstream merges easier.

## Motivation and Context

https://jira.lingsoft.fi/browse/SIMPLYE-221

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.