### PR TITLE
Show admin's first name instead of internal authentication ID

### DIFF
--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -13,6 +13,7 @@ export interface ContextProviderProps extends React.Props<ContextProvider> {
   showCircEventsDownload?: boolean;
   settingUp?: boolean;
   email?: string;
+  givenName?: string;
   roles?: {
     role: string;
     library?: string;
@@ -36,6 +37,7 @@ export default class ContextProvider extends React.Component<
     this.admin = new Admin(
       props.roles || [],
       props.email || null,
+      props.givenName || null,
       props.authType || null
     );
     this.pathFor = (collectionUrl: string, bookUrl: string, tab?: string) => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -225,7 +225,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
             {sitewideLinkItems.map((item) =>
               this.renderLinkItem(item, currentPathname)
             )}
-            {this.context.admin.email && (
+            {(this.context.admin.email || this.context.admin.givenName) && (
               <li className="dropdown">
                 <Button
                   className="account-dropdown-toggle transparent"
@@ -235,7 +235,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                   callback={this.toggleAccountDropdown}
                   content={
                     <span>
-                      {this.context.admin.email} <GenericWedgeIcon />
+                      {this.context.admin.givenName || this.context.admin.email}{" "}
+                      <GenericWedgeIcon />
                     </span>
                   }
                 />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,11 @@ interface ConfigurationSettings {
   /** `email` will be the email address of the currently logged in admin. */
   email?: string;
 
+  /** `givenName` will be the first name of currently logged in admin.
+      only available for externally authenticated users (who will have no
+      email). */
+  givenName?: string;
+
   /** `roles` contains the logged in admin's roles: system admininstrator,
       or library manager or librarian for one or more libraries. */
   roles?: {

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -3,6 +3,7 @@ import { AdminAuthType, AdminRoleData } from "../interfaces";
 export default class Admin {
   roles: AdminRoleData[];
   email: string | null = null;
+  givenName: string | null = null;
   private authType: AdminAuthType = "password";
   private systemAdmin: boolean = false;
   private sitewideLibraryManager: boolean = false;
@@ -13,10 +14,12 @@ export default class Admin {
   constructor(
     roles: AdminRoleData[],
     email?: string,
+    givenName?: string,
     authType?: AdminAuthType
   ) {
     this.roles = roles;
     this.email = email;
+    this.givenName = givenName;
     this.authType = authType;
     for (const role of roles) {
       switch (role.role) {


### PR DESCRIPTION
## Description

We don't have an e-mail for externally authenticated users and currently show the external auth user ID in admin UI, which will not make much sense for the admin users.

We can store the user's first name in the session and show that instead when we don't have an e-mail:

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-271> - Display first name instead of auth ID in circulation admin UI
