### PR TITLE
Indicate default library in header and under settings

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -193,6 +193,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                   aria-selected={currentLibrary === library.short_name}
                 >
                   {library.name || library.short_name}
+                  {library.is_default && " (default)"}
                 </option>
               ))}
             </EditableInput>

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -54,7 +54,8 @@ export class Libraries extends GenericEditableConfigList<
   }
 
   label(item): string {
-    return item[this.labelKey] || item.short_name || item.uuid;
+    const name = item[this.labelKey] || item.short_name || item.uuid;
+    return item.is_default ? `${name} (default)` : name;
   }
 
   canCreate() {


### PR DESCRIPTION
As the default library now has special functionality, makes sense to indicate which library is the default one.

The functionality I'm referring to is:

- Collections defined for default library being available for all libraries
- Default library is shown for unauthenticated users.

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-263> - Implement custom lane management for local librarians

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
