### PR TITLE
Statistics improvements (Location and loan duration filtering)

### DIFF
--- a/src/finland/OpenSearchAnalyticsContext.tsx
+++ b/src/finland/OpenSearchAnalyticsContext.tsx
@@ -1,12 +1,17 @@
 import * as React from "react";
 import { createContext, useEffect, useState } from "react";
-import { KeyValuePair, NameValuePair, readable } from "./finlandUtils";
+import {
+  KeyValuePair,
+  NameValuePair,
+  loanDurationOptions,
+  readable,
+} from "./finlandUtils";
 const termsEndpoint = "/admin/events/terms";
 const histogramEndpoint = "/admin/events/histogram";
 const facetsEndpoint = "/admin/events/facets";
 const municipalityEndpoint = "/admin/municipalities";
 
-type BucketItem = {
+export type BucketItem = {
   key: string;
   doc_count: number;
 };
@@ -132,14 +137,19 @@ export function OpenSearchAnalyticsContextProvider({
   }
 
   function filterToOptions(filterKey: string, buckets?: BucketItem[]) {
+    if (filterKey === "duration") {
+      return [...loanDurationOptions]; // Spread to trigger SelectSearch re-render
+    }
     if (!buckets?.length) {
       return [];
     }
     if (filterKey === "location") {
-      return buckets.map((item) => ({
-        value: item.key,
-        name: municipalityMapping[item.key] || item.key,
-      }));
+      return buckets
+        .map((item) => ({
+          value: item.key,
+          name: municipalityMapping[item.key] || item.key,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
     }
     return buckets
       .map((item) => ({
@@ -152,6 +162,9 @@ export function OpenSearchAnalyticsContextProvider({
   function labelizeFilterChip({ key, value }: KeyValuePair) {
     if (key === "location") {
       return `${readable(key)}: ${municipalityMapping[value] || value}`;
+    }
+    if (key === "duration") {
+      return `${readable(key)}: ${readable(value) || value}`;
     }
     return `${readable(key)}: ${value}`;
   }

--- a/src/finland/components/EventBarChart.tsx
+++ b/src/finland/components/EventBarChart.tsx
@@ -36,7 +36,13 @@ export function EventBarChart() {
     setTimeframeOffset,
   } = useFilters();
 
-  const { facetData, eventData, fetchEventData } = useOpenSearchAnalytics();
+  const {
+    facetData,
+    eventData,
+    fetchEventData,
+    filterToOptions,
+    labelizeFilterChip,
+  } = useOpenSearchAnalytics();
 
   useEffect(() => {
     const selections: KeyValuePair[] = [...activeFilters];
@@ -67,12 +73,14 @@ export function EventBarChart() {
         setStartDate={setStartDate}
         endDate={endDate}
         setEndDate={setEndDate}
+        filterToOptions={filterToOptions}
       />
 
       <FilterChips
         activeFilters={activeFilters}
         toggleFilter={toggleFilter}
         clearFilters={clearFilters}
+        labelize={labelizeFilterChip}
       />
 
       <div className="chart-prefix">

--- a/src/finland/components/FilterChips.tsx
+++ b/src/finland/components/FilterChips.tsx
@@ -1,16 +1,18 @@
 import * as React from "react";
-import { KeyValuePair, readable } from "../finlandUtils";
+import { KeyValuePair } from "../finlandUtils";
 
 type FilterChipsProps = {
   activeFilters: KeyValuePair[];
   toggleFilter: (selection: KeyValuePair) => void;
   clearFilters: () => void;
+  labelize: (item: KeyValuePair) => string;
 };
 
 export function FilterChips({
   activeFilters,
   toggleFilter,
   clearFilters,
+  labelize,
 }: FilterChipsProps) {
   return (
     <div className="chip-container">
@@ -22,7 +24,7 @@ export function FilterChips({
               onClick={() => toggleFilter(item)}
               isSingle
             >
-              {readable(item.key)}: {item.value}
+              {labelize(item)}
             </Chip>
           ))}
           <Chip

--- a/src/finland/components/FilterInputs.tsx
+++ b/src/finland/components/FilterInputs.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { KeyValuePair, filterKeys, readable, EventKey } from "../finlandUtils";
-import { FacetData } from "../OpenSearchAnalyticsContext";
+import { FacetData, FilterToOptionsFunc } from "../OpenSearchAnalyticsContext";
 import SelectSearch from "react-select-search";
 import { fuzzySearch } from "react-select-search";
 
@@ -11,6 +11,7 @@ type FilterInputsProps = {
   setStartDate: (newDate: string) => void;
   endDate: string;
   setEndDate: (newDate: string) => void;
+  filterToOptions: FilterToOptionsFunc;
 };
 
 export function FilterInputs({
@@ -20,15 +21,12 @@ export function FilterInputs({
   setStartDate,
   endDate,
   setEndDate,
+  filterToOptions,
 }: FilterInputsProps) {
   return (
     <div className="input-wrapper">
       {filterKeys.map((key) => {
-        const options =
-          facetData[key]?.buckets.map((item) => ({
-            value: item.key,
-            name: item.key,
-          })) || [];
+        const options = filterToOptions(key, facetData[key]?.buckets);
         const label = readable(key);
         return (
           <div key={key} className="flex-col">

--- a/src/finland/components/Histogram.tsx
+++ b/src/finland/components/Histogram.tsx
@@ -42,6 +42,8 @@ export function Histogram() {
     facetData,
     histogramData,
     fetchHistogramData,
+    filterToOptions,
+    labelizeFilterChip,
   } = useOpenSearchAnalytics();
 
   const {
@@ -149,12 +151,14 @@ export function Histogram() {
         setStartDate={setStartDate}
         endDate={endDate}
         setEndDate={setEndDate}
+        filterToOptions={filterToOptions}
       />
 
       <FilterChips
         activeFilters={activeFilters}
         toggleFilter={toggleFilter}
         clearFilters={clearFilters}
+        labelize={labelizeFilterChip}
       />
 
       <div className="chart-prefix">

--- a/src/finland/finlandUtils.ts
+++ b/src/finland/finlandUtils.ts
@@ -20,6 +20,7 @@ export interface IEvent {
   time: string;
   contributors: string[] | null;
   start: string;
+  duration: string | null;
   date?: string;
 }
 
@@ -76,10 +77,14 @@ export const readableNames: Record<string, string> = {
   genres: "Genre",
   audience: "Kohderyhmä",
   location: "Sijainti",
+  duration: "Laina-aika (palautukset)",
   // Time intervals
   hour: "Tunti",
   day: "Päivä",
   month: "Kuukausi",
+  // Loan duration options:
+  under_2h: "Alle 2h",
+  over_2h: "Yli 2h",
 };
 
 export const readable = (input: string): string =>
@@ -91,6 +96,7 @@ export const filterKeys = [
   "audience",
   "genres",
   "location",
+  "duration",
 ];
 
 export const intervals = ["hour", "day", "month"];
@@ -133,6 +139,13 @@ export const timeframeOptions: Record<Timeframe, TimeframeOption> = {
       getNumericDateWithYearAndWeekday(new Date(startDate)),
   },
 };
+
+const loanDurations = ["under_2h", "over_2h"];
+
+export const loanDurationOptions = loanDurations.map((key) => ({
+  value: key,
+  name: readable(key),
+}));
 
 /*
  * General helper functions

--- a/src/finland/finlandUtils.ts
+++ b/src/finland/finlandUtils.ts
@@ -27,12 +27,15 @@ export type EventKey = keyof IEvent;
 
 export type KeyValuePair = { key: string; value: string };
 
+export type NameValuePair = { name: string; value: string };
+
 export const eventTypes = {
   circulation_manager_check_out: "circulation_manager_check_out",
   circulation_manager_check_in: "circulation_manager_check_in",
   circulation_manager_fulfill: "circulation_manager_fulfill",
   circulation_manager_hold_place: "circulation_manager_hold_place",
   circulation_manager_hold_release: "circulation_manager_hold_release",
+  circulation_manager_new_patron: "circulation_manager_new_patron",
   distributor_check_out: "distributor_check_out",
   distributor_check_in: "distributor_check_in",
   distributor_hold_place: "distributor_hold_place",
@@ -52,6 +55,7 @@ export const readableNames: Record<string, string> = {
   [eventTypes.circulation_manager_fulfill]: "Toimitukset",
   [eventTypes.circulation_manager_hold_place]: "Varaukset, pyyntö",
   [eventTypes.circulation_manager_hold_release]: "Varaukset, nouto",
+  [eventTypes.circulation_manager_new_patron]: "Uudet asiakkaat",
   [eventTypes.distributor_check_out]: "Lainaukset",
   [eventTypes.distributor_check_in]: "Palautukset",
   [eventTypes.distributor_hold_place]: "Varaukset, pyyntö",
@@ -71,6 +75,7 @@ export const readableNames: Record<string, string> = {
   fiction: "Fiktio",
   genres: "Genre",
   audience: "Kohderyhmä",
+  location: "Sijainti",
   // Time intervals
   hour: "Tunti",
   day: "Päivä",
@@ -80,7 +85,13 @@ export const readableNames: Record<string, string> = {
 export const readable = (input: string): string =>
   readableNames[input] || input;
 
-export const filterKeys = ["publisher", "language", "audience", "genres"];
+export const filterKeys = [
+  "publisher",
+  "language",
+  "audience",
+  "genres",
+  "location",
+];
 
 export const intervals = ["hour", "day", "month"];
 export type Interval = "hour" | "day" | "month";

--- a/src/finland/tests/EventBarChart.test.tsx
+++ b/src/finland/tests/EventBarChart.test.tsx
@@ -6,6 +6,7 @@ import {
   eventDataFixture,
   histogramDataFixture,
 } from "./fixtures";
+import { mockFilterToOptions } from "./mocks";
 
 /* Mock globals and dependencies */
 
@@ -57,16 +58,11 @@ jest.mock("../hooks/useOpenSearchAnalytics", () => ({
     histogramData: histogramDataFixture.data,
     fetchHistogramData: jest.fn(() => null),
     isReady: true,
-    filterToOptions: jest.fn((_, buckets) =>
-      buckets.map((item) => ({
-        value: item.key,
-        name: item.key,
-      }))
-    ),
+    filterToOptions: jest.fn(mockFilterToOptions),
   })),
 }));
 
-const eventTypesLenght = eventDataFixture.data.type.length;
+const eventTypesLength = eventDataFixture.data.type.length;
 
 afterAll(() => {
   jest.resetAllMocks();
@@ -79,6 +75,6 @@ describe("EventBarChart", () => {
     const bars = document.querySelectorAll(".recharts-bar-rectangle");
 
     // Check that there's as many bars as event types
-    expect(bars.length === eventTypesLenght).toBeTruthy();
+    expect(bars.length === eventTypesLength).toBeTruthy();
   });
 });

--- a/src/finland/tests/EventBarChart.test.tsx
+++ b/src/finland/tests/EventBarChart.test.tsx
@@ -57,6 +57,12 @@ jest.mock("../hooks/useOpenSearchAnalytics", () => ({
     histogramData: histogramDataFixture.data,
     fetchHistogramData: jest.fn(() => null),
     isReady: true,
+    filterToOptions: jest.fn((_, buckets) =>
+      buckets.map((item) => ({
+        value: item.key,
+        name: item.key,
+      }))
+    ),
   })),
 }));
 

--- a/src/finland/tests/FilterChips.test.tsx
+++ b/src/finland/tests/FilterChips.test.tsx
@@ -22,6 +22,7 @@ describe("FilterChips", () => {
         activeFilters={activeFilters}
         toggleFilter={doNothing}
         clearFilters={doNothing}
+        labelize={(item) => `${item.key}: ${item.value}`}
       />
     );
 
@@ -39,6 +40,7 @@ describe("FilterChips", () => {
         activeFilters={activeFilters}
         toggleFilter={toggleFilterMock}
         clearFilters={doNothing}
+        labelize={(item) => `${item.key}: ${item.value}`}
       />
     );
 
@@ -57,6 +59,7 @@ describe("FilterChips", () => {
         activeFilters={activeFilters}
         toggleFilter={doNothing}
         clearFilters={clearFiltersMock}
+        labelize={(item) => `${item.key}: ${item.value}`}
       />
     );
 

--- a/src/finland/tests/FilterInputs.test.tsx
+++ b/src/finland/tests/FilterInputs.test.tsx
@@ -24,6 +24,7 @@ describe("FilterInputs", () => {
         setStartDate={doNothing}
         endDate=""
         setEndDate={doNothing}
+        filterToOptions={() => []}
       />
     );
 
@@ -47,6 +48,12 @@ describe("FilterInputs", () => {
         setStartDate={doNothing}
         endDate=""
         setEndDate={doNothing}
+        filterToOptions={(_, buckets) =>
+          buckets.map((item) => ({
+            value: item.key,
+            name: item.key,
+          }))
+        }
       />
     );
 
@@ -80,6 +87,7 @@ describe("FilterInputs", () => {
         setStartDate={setStartDateMock}
         endDate="2023-12-31"
         setEndDate={setEndDateMock}
+        filterToOptions={() => []}
       />
     );
 

--- a/src/finland/tests/FilterInputs.test.tsx
+++ b/src/finland/tests/FilterInputs.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import { FilterInputs } from "../components/FilterInputs";
 import { facetDataFixture } from "./fixtures";
 import { filterKeys } from "../finlandUtils";
+import { mockFilterToOptions } from "./mocks";
 
 function doNothing() {
   /* do nothing */
@@ -24,7 +25,7 @@ describe("FilterInputs", () => {
         setStartDate={doNothing}
         endDate=""
         setEndDate={doNothing}
-        filterToOptions={() => []}
+        filterToOptions={mockFilterToOptions}
       />
     );
 
@@ -48,12 +49,7 @@ describe("FilterInputs", () => {
         setStartDate={doNothing}
         endDate=""
         setEndDate={doNothing}
-        filterToOptions={(_, buckets) =>
-          buckets.map((item) => ({
-            value: item.key,
-            name: item.key,
-          }))
-        }
+        filterToOptions={mockFilterToOptions}
       />
     );
 
@@ -87,7 +83,7 @@ describe("FilterInputs", () => {
         setStartDate={setStartDateMock}
         endDate="2023-12-31"
         setEndDate={setEndDateMock}
-        filterToOptions={() => []}
+        filterToOptions={mockFilterToOptions}
       />
     );
 

--- a/src/finland/tests/FinlandStats.test.tsx
+++ b/src/finland/tests/FinlandStats.test.tsx
@@ -7,6 +7,7 @@ import {
   facetDataFixture,
   histogramDataFixture,
 } from "./fixtures";
+import { mockFilterToOptions } from "./mocks";
 
 /* Mock globals and dependencies */
 
@@ -42,12 +43,7 @@ jest.mock("../hooks/useOpenSearchAnalytics", () => ({
     histogramData: histogramDataFixture.data,
     fetchHistogramData: jest.fn(() => null),
     isReady: true,
-    filterToOptions: jest.fn((_, buckets) =>
-      buckets.map((item) => ({
-        value: item.key,
-        name: item.key,
-      }))
-    ),
+    filterToOptions: jest.fn(mockFilterToOptions),
   })),
 }));
 

--- a/src/finland/tests/FinlandStats.test.tsx
+++ b/src/finland/tests/FinlandStats.test.tsx
@@ -42,6 +42,12 @@ jest.mock("../hooks/useOpenSearchAnalytics", () => ({
     histogramData: histogramDataFixture.data,
     fetchHistogramData: jest.fn(() => null),
     isReady: true,
+    filterToOptions: jest.fn((_, buckets) =>
+      buckets.map((item) => ({
+        value: item.key,
+        name: item.key,
+      }))
+    ),
   })),
 }));
 

--- a/src/finland/tests/Histogram.test.tsx
+++ b/src/finland/tests/Histogram.test.tsx
@@ -6,6 +6,7 @@ import {
   facetDataFixture,
   histogramDataFixture,
 } from "./fixtures";
+import { mockFilterToOptions } from "./mocks";
 
 /* Mock globals and dependencies */
 
@@ -57,16 +58,11 @@ jest.mock("../hooks/useOpenSearchAnalytics", () => ({
     histogramData: histogramDataFixture.data,
     fetchHistogramData: jest.fn(() => null),
     isReady: true,
-    filterToOptions: jest.fn((_, buckets) =>
-      buckets.map((item) => ({
-        value: item.key,
-        name: item.key,
-      }))
-    ),
+    filterToOptions: jest.fn(mockFilterToOptions),
   })),
 }));
 
-const eventTypesLenght = eventDataFixture.data.type.length;
+const eventTypesLength = eventDataFixture.data.type.length;
 
 afterAll(() => {
   jest.resetAllMocks();
@@ -79,11 +75,11 @@ describe("Histogram", () => {
     const lines = document.querySelectorAll(".recharts-line");
 
     // Check that there's as many bars as event types
-    for (let i = 0; i < eventTypesLenght; i++) {
+    for (let i = 0; i < eventTypesLength; i++) {
       expect(lines[i]).toBeInTheDocument();
     }
     // ... but no more than that
-    expect(lines[eventTypesLenght]).toBeFalsy();
+    expect(lines[eventTypesLength]).toBeFalsy();
   });
 
   it("toggles a line when clicking a legend", () => {
@@ -92,6 +88,6 @@ describe("Histogram", () => {
     const lines = document.querySelectorAll(".recharts-legend-item");
 
     // Check that there's as many lines as event types
-    expect(lines.length === eventTypesLenght).toBeTruthy();
+    expect(lines.length === eventTypesLength).toBeTruthy();
   });
 });

--- a/src/finland/tests/Histogram.test.tsx
+++ b/src/finland/tests/Histogram.test.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import { render } from "@testing-library/react";
 import { Histogram } from "../components/Histogram";
 import {
-  facetDataFixture,
   eventDataFixture,
+  facetDataFixture,
   histogramDataFixture,
 } from "./fixtures";
 
@@ -57,6 +57,12 @@ jest.mock("../hooks/useOpenSearchAnalytics", () => ({
     histogramData: histogramDataFixture.data,
     fetchHistogramData: jest.fn(() => null),
     isReady: true,
+    filterToOptions: jest.fn((_, buckets) =>
+      buckets.map((item) => ({
+        value: item.key,
+        name: item.key,
+      }))
+    ),
   })),
 }));
 

--- a/src/finland/tests/mocks.ts
+++ b/src/finland/tests/mocks.ts
@@ -1,0 +1,17 @@
+import { BucketItem } from "../OpenSearchAnalyticsContext";
+import { loanDurationOptions } from "../finlandUtils";
+
+export function mockFilterToOptions(filterKey: string, buckets?: BucketItem[]) {
+  if (filterKey === "duration") {
+    return [...loanDurationOptions];
+  }
+  if (!buckets?.length) {
+    return [];
+  }
+  return buckets
+    .map((item) => ({
+      value: item.key,
+      name: item.key,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/stylesheets/finland_statistics.scss
+++ b/src/stylesheets/finland_statistics.scss
@@ -103,8 +103,13 @@
     background: var(--highlight-background);
     border: solid 1px hsl(142, 25%, 42%);
   }
+  .recharts-legend-item {
+    user-select: none;
+  }
 
   .recharts-legend-item.inactive .recharts-legend-item-text {
+    text-decoration: line-through;
+    text-decoration-color: #666;
     opacity: 0.8;
   }
   .chart-prefix {


### PR DESCRIPTION
## Description

####  Location as facet filter in statistics view
- Allow filtering patron events by location (ie. municipality)
- Context: https://jira.lingsoft.fi/browse/SIMPLYE-239

#### Loan duration facet filter in statistics view
- Allow filtering checkout events by loan duration (over/under 2h)
- Context: https://jira.lingsoft.fi/browse/SIMPLYE-181

### Misc
- Enable solo-toggle event types with legend double-click in graph views
- Add "translation" to new patron event
