### PR TITLE
Fix broken dropdown item selection in library settings

### DIFF
--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -182,8 +182,8 @@ export default class EditableInput extends React.Component<
 
   handleChange() {
     if (
-      !this.props.readOnly &&
-      (!this.props.onChange || this.props.onChange(this.getValue()) !== false)
+      !this.props.onChange ||
+      this.props.onChange(this.getValue()) !== false
     ) {
       let value = this.state.value;
       let checked = this.state.checked;

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -93,15 +93,11 @@ export default class LibraryEditForm extends React.Component<
       }
     };
 
-    const librarySettingInheritanceInfo = this.props.item?.is_default ? (
-      <p>
-        This is the default library. The values set for this library will be
-        used as defaults for other libraries.
-      </p>
-    ) : (
-      <p>
-        This library inherits settings from the default library. If a setting is
-        left empty, the default library value will be used.
+    const librarySettingInheritanceInfo = (
+      <p key="inheritance-info">
+        {this.props.item?.is_default
+          ? "This is the default library. The values set for this library will be used as defaults for other libraries."
+          : "This library inherits settings from the default library. If a setting is left empty, the default library value will be used."}
       </p>
     );
 
@@ -187,6 +183,7 @@ export default class LibraryEditForm extends React.Component<
   renderAnnouncements(setting: SettingData, value) {
     return (
       <AnnouncementsSection
+        key={setting.key}
         setting={{ ...setting, ...{ format: "date-range" } }}
         value={value && JSON.parse(value)}
         ref={this.announcementsRef}
@@ -200,6 +197,7 @@ export default class LibraryEditForm extends React.Component<
     // when the iterator in renderFieldset gets to them, they'll get skipped over, not rendered a second time.
     return (
       <PairedMenus
+        key={setting.key}
         inputListSetting={setting}
         dropdownSetting={dropdownSetting}
         item={this.props.item}


### PR DESCRIPTION
## Description

Under library settings in admin UI, when selecting an option under e.g. "Enabled entry points", the option just flashes back to the first value in the dropdown. So it effectively prevents choosing anything but the first value. 

This PR fixes the dropdown issue as well as some React warnings about missing 'key' attribute.

## Motivation and Context

https://jira.lingsoft.fi/browse/SIMPLYE-352 Dropdown menu issue in circulation admin library settings page
