### PR TITLE
EKIR-217 Button for extended csv download

### DIFF
--- a/src/finland/components/FinlandStats.tsx
+++ b/src/finland/components/FinlandStats.tsx
@@ -35,7 +35,7 @@ export const statTabs: TabOption[] = [
   },
   {
     key: "loan-stats",
-    label: "Lainausmäärät (Excel)",
+    label: "Lainausmäärät (Excel/CSV)",
     narrowLabel: "Lainaukset",
   },
 ];

--- a/src/finland/components/LoanReport.tsx
+++ b/src/finland/components/LoanReport.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Button } from "library-simplified-reusable-components";
 
 const DOWNLOAD_EXCEL_SLUG = "/admin/circulation_loan_statistics_excel";
+const DOWNLOAD_CSV_SLUG = "/admin/circulation_loan_statistics_csv";
 
 interface LoanReportProps {
   library?: string;
@@ -22,6 +23,23 @@ export function LoanReport({ library }: LoanReportProps) {
     const queryString = new URLSearchParams(params).toString();
 
     const url = `/${library}${DOWNLOAD_EXCEL_SLUG}?${queryString}`;
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.target = "_blank";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  }
+
+  function downloadLoanCSV() {
+    const params = {
+      date: startDate,
+      dateEnd: endDate,
+    };
+    const queryString = new URLSearchParams(params).toString();
+
+    const url = `/${library}${DOWNLOAD_CSV_SLUG}?${queryString}`;
 
     const link = document.createElement("a");
     link.href = url;
@@ -57,12 +75,20 @@ export function LoanReport({ library }: LoanReportProps) {
           />
         </div>
       </div>
-      <Button
-        data-testid="download-button"
-        className="inverted left-align"
-        callback={downloadLoanExcel}
-        content="Lataa Excel-taulukkona"
-      />
+      <div>
+        <Button
+          data-testid="download-excel-button"
+          className="inverted left-align"
+          callback={downloadLoanExcel}
+          content="Lataa Excel-taulukkona"
+        />
+        <Button
+          data-testid="download-csv-button"
+          className="inverted left-align"
+          callback={downloadLoanCSV}
+          content="Lataa CSV-tiedostona"
+        />
+      </div>
     </div>
   );
 }

--- a/src/finland/tests/LoanReport.test.tsx
+++ b/src/finland/tests/LoanReport.test.tsx
@@ -20,9 +20,16 @@ describe("LoanReport", () => {
     expect(endDateInput).toHaveValue("2023-03-31");
   });
 
-  it("does not crash when clicking download button", () => {
+  it("does not crash when clicking download excel button", () => {
     const { getByTestId } = render(<LoanReport library="test-library" />);
-    const downloadButton = getByTestId("download-button");
+    const downloadButton = getByTestId("download-excel-button");
+
+    fireEvent.click(downloadButton);
+  });
+
+  it("does not crash when clicking download csv button", () => {
+    const { getByTestId } = render(<LoanReport library="test-library" />);
+    const downloadButton = getByTestId("download-csv-button");
 
     fireEvent.click(downloadButton);
   });


### PR DESCRIPTION
## Description
Added button to for csv report download.

## Motivation and Context
To trigger csv export, as excel generation is rather heavy in its current state; proxies will timeout waiting.

## How Has This Been Tested?
Tested against development instance.



